### PR TITLE
Prepare happybase-0.31.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 [1]: https://pypi.org/project/google-cloud-happybase/#history
 
 
+## 0.31.0 (2018-10-05)
+
+### Dependencies
+
+- Update to use `google.cloud.bigtable 0.31.0`
+
+
 ## 0.30.2 (2018-10-05)
 
 ### Dependencies

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-bigtable >= 0.30.2, < 0.31dev',
+    'google-cloud-bigtable >= 0.31.0',
 ]
 
 SETUP_BASE.pop('url')


### PR DESCRIPTION
- Pins `google-cloud-bigtable >= 0.31.0`, removing upper bound since bigtable is now beta.