### PR TITLE
Using mutate_rows() instead of row.commit()

### DIFF
--- a/src/google/cloud/happybase/batch.py
+++ b/src/google/cloud/happybase/batch.py
@@ -100,6 +100,8 @@ class Batch(object):
             self._delete_range = TimestampRange(end=next_timestamp)
 
         self._transaction = transaction
+        self._batcher = self._table._low_level_table.mutations_batcher(
+            flush_count=self._batch_size)
 
         # Internal state for tracking mutations.
         self._row_map = {}
@@ -107,10 +109,10 @@ class Batch(object):
 
     def send(self):
         """Send / commit the batch of mutations to the server."""
-        for row in self._row_map.values():
-            # commit() does nothing if row hasn't accumulated any mutations.
-            row.commit()
-
+        #for row in self._row_map.values():
+        #    # commit() does nothing if row hasn't accumulated any mutations.
+        #    row.commit()
+        self._batcher.flush()
         self._row_map.clear()
         self._mutation_count = 0
 

--- a/src/google/cloud/happybase/batch.py
+++ b/src/google/cloud/happybase/batch.py
@@ -100,8 +100,6 @@ class Batch(object):
             self._delete_range = TimestampRange(end=next_timestamp)
 
         self._transaction = transaction
-        self._batcher = self._table._low_level_table.mutations_batcher(
-            flush_count=self._batch_size)
 
         # Internal state for tracking mutations.
         self._row_map = {}
@@ -109,10 +107,8 @@ class Batch(object):
 
     def send(self):
         """Send / commit the batch of mutations to the server."""
-        #for row in self._row_map.values():
-        #    # commit() does nothing if row hasn't accumulated any mutations.
-        #    row.commit()
-        self._batcher.flush()
+        table = self._table._low_level_table
+        table.mutate_rows(self._row_map.values())
         self._row_map.clear()
         self._mutation_count = 0
 

--- a/unit_tests/test_batch.py
+++ b/unit_tests/test_batch.py
@@ -82,7 +82,6 @@ class TestBatch(unittest.TestCase):
 
     def test_constructor_with_non_positive_batch_size(self):
         table = object()
-
         batch_size = -10
         with self.assertRaises(ValueError):
             self._make_one(table, batch_size=batch_size)
@@ -92,7 +91,6 @@ class TestBatch(unittest.TestCase):
 
     def test_constructor_with_batch_size_and_transactional(self):
         table = object()
-
         batch_size = 1
         transaction = True
         with self.assertRaises(TypeError):
@@ -102,12 +100,11 @@ class TestBatch(unittest.TestCase):
     def test_send(self):
         low_level_table = _MockLowLevelTable()
         table = _MockTable(low_level_table)
-
         batch = self._make_one(table)
 
         batch._row_map = row_map = _MockRowMap()
-        row_map['row-key1'] = _MockRow()
-        row_map['row-key2'] = _MockRow()
+        row_map['row-key1'] = row1 = _MockRow()
+        row_map['row-key2'] = row2 = _MockRow()
         batch._mutation_count = 1337
 
         self.assertEqual(row_map.clear_count, 0)
@@ -118,7 +115,8 @@ class TestBatch(unittest.TestCase):
         batch.send()
         self.assertEqual(row_map.clear_count, 1)
         self.assertEqual(batch._mutation_count, 0)
-        self.assertEqual(len(table._low_level_table.rows_mutate), 2)
+        self.assertEqual(table._low_level_table.rows_mutate,
+                         [row1, row2])
         self.assertEqual(row_map, {})
 
     def test__try_send_no_batch_size(self):

--- a/unit_tests/test_batch.py
+++ b/unit_tests/test_batch.py
@@ -34,9 +34,7 @@ class TestBatch(unittest.TestCase):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
-        low_level_table = _MockLowLevelTable()
-        table = _MockTable(low_level_table)
-
+        table = object()
         batch = self._make_one(table)
         self.assertEqual(batch._table, table)
         self.assertEqual(batch._batch_size, None)

--- a/unit_tests/test_batch.py
+++ b/unit_tests/test_batch.py
@@ -34,7 +34,10 @@ class TestBatch(unittest.TestCase):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
-        table = object()
+        #table = object()
+        low_level_table = _MockLowLevelTable()
+        table = _MockTable(low_level_table)
+
         batch = self._make_one(table)
         self.assertEqual(batch._table, table)
         self.assertEqual(batch._batch_size, None)
@@ -48,7 +51,10 @@ class TestBatch(unittest.TestCase):
         from google.cloud._helpers import _datetime_from_microseconds
         from google.cloud.bigtable.row_filters import TimestampRange
 
-        table = object()
+        #table = object()
+        low_level_table = _MockLowLevelTable()
+        table = _MockTable(low_level_table)
+
         timestamp = 144185290431
         batch_size = 42
         transaction = False  # Must be False when batch_size is non-null
@@ -72,7 +78,10 @@ class TestBatch(unittest.TestCase):
         import warnings
         from google.cloud.happybase.batch import _WAL_WARNING
 
-        table = object()
+        #table = object()
+        low_level_table = _MockLowLevelTable()
+        table = _MockTable(low_level_table)
+
         wal = object()
         with warnings.catch_warnings(record=True) as warned:
             self._make_one(table, wal=wal)
@@ -81,7 +90,10 @@ class TestBatch(unittest.TestCase):
         self.assertIn(_WAL_WARNING, str(warned[0].message))
 
     def test_constructor_with_non_positive_batch_size(self):
-        table = object()
+        #table = object()
+        low_level_table = _MockLowLevelTable()
+        table = _MockTable(low_level_table)
+
         batch_size = -10
         with self.assertRaises(ValueError):
             self._make_one(table, batch_size=batch_size)
@@ -90,7 +102,10 @@ class TestBatch(unittest.TestCase):
             self._make_one(table, batch_size=batch_size)
 
     def test_constructor_with_batch_size_and_transactional(self):
-        table = object()
+        #table = object()
+        low_level_table = _MockLowLevelTable()
+        table = _MockTable(low_level_table)
+
         batch_size = 1
         transaction = True
         with self.assertRaises(TypeError):
@@ -543,7 +558,11 @@ class _MockLowLevelTable(object):
         self.kwargs = kwargs
         self.rows_made = []
         self.mock_row = None
+        #self.mutations_batcher = object()
 
     def row(self, row_key):
         self.rows_made.append(row_key)
         return self.mock_row
+    
+    def mutations_batcher(self, flush_count):
+        pass

--- a/unit_tests/test_batch.py
+++ b/unit_tests/test_batch.py
@@ -106,8 +106,8 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(table)
 
         batch._row_map = row_map = _MockRowMap()
-        row_map['row-key1'] = row1 = _MockRow()
-        row_map['row-key2'] = row2 = _MockRow()
+        row_map['row-key1'] = _MockRow()
+        row_map['row-key2'] = _MockRow()
         batch._mutation_count = 1337
 
         self.assertEqual(row_map.clear_count, 0)


### PR DESCRIPTION
This is a fix for https://github.com/googleapis/google-cloud-python-happybase/issues/4