### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ SETUP_BASE.pop('url')
 
 setup(
     name='google-cloud-happybase',
-    version=version,
+    version=setuptools.sic(version),
     description='Client library for Google Cloud Bigtable: HappyBase layer',
     long_description=README,
     url='https://github.com/googleapis/google-cloud-python-happybase',

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@
 
 import os
 
-from setuptools import find_packages
-from setuptools import setup
+import setuptools
 
 version = '0.33.0'
 
@@ -58,7 +57,7 @@ REQUIREMENTS = [
 
 SETUP_BASE.pop('url')
 
-setup(
+setuptools.setup(
     name='google-cloud-happybase',
     version=setuptools.sic(version),
     description='Client library for Google Cloud Bigtable: HappyBase layer',
@@ -68,7 +67,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages('src'),
+    packages=setuptools.find_packages('src'),
     package_dir={'': 'src'},
     install_requires=REQUIREMENTS,
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,21 @@ import os
 
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 version = '0.33.0'
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -59,7 +74,7 @@ SETUP_BASE.pop('url')
 
 setuptools.setup(
     name='google-cloud-happybase',
-    version=setuptools.sic(version),
+    version=sic(version),
     description='Client library for Google Cloud Bigtable: HappyBase layer',
     long_description=README,
     url='https://github.com/googleapis/google-cloud-python-happybase',


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from -patch to .patch which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.